### PR TITLE
Ensure formatter is set

### DIFF
--- a/mqlog/__init__.py
+++ b/mqlog/__init__.py
@@ -3,6 +3,8 @@
 import asyncio
 import logging
 
+_default_formatter = logging.Formatter(logging._default_fmt)
+
 
 class MqttHandler(logging.Handler):
     """
@@ -58,6 +60,11 @@ class MqttHandler(logging.Handler):
         self.buffer.append(self.format(record))
         if self._should_flush(record):
             self.will_flush.set()
+
+    # Override Handler.format to prevent errors if there's no formatter set
+    def format(self, record):
+        fmt = self.formatter or _default_formatter
+        return fmt.format(record)
 
     # Named with an underscore to avoid conflict with logging.Handler.flush
     async def _flush(self):

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -26,6 +26,11 @@ class TestMqttHandler(TestCase):
         self.logger.addHandler(self.handler)
         self.logger.setLevel(logging.INFO)
 
+    def test_default_formatter(self):
+        """Handler should use default formatter if none is set"""
+        self.handler.setFormatter(None)
+        self.logger.info("Test message")  # Would error if no formatter
+
     def test_no_flush(self):
         """Buffer should not be flushed until capacity/level reached"""
         self.handler.flush_level = logging.WARNING


### PR DESCRIPTION
- **Use the log level of the parent logger by default**
- **Prevent errors if no formatter is provided**
