### PR TITLE
Ensure buffer can't overflow; update uptime check

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,16 +6,16 @@ class Mock:
     """A mock callable object that stores its calls."""
 
     def __init__(self, return_value=None, side_effect=None):
-        self._return_value = return_value
-        self._side_effect = side_effect
+        self.return_value = return_value
+        self.side_effect = side_effect
         self._calls = []
 
     def __call__(self, *args, **kwargs):
         """Call the mock and store the call details."""
         self._calls.append(call(*args[1:], **kwargs))  # Skip the first argument (self)
-        if self._side_effect:
-            raise self._side_effect
-        return self._return_value
+        if self.side_effect:
+            raise self.side_effect
+        return self.return_value
 
     def assert_called(self):
         """Assert that the mock was called at least once."""


### PR DESCRIPTION
This takes advantage of amqc's MQTTClient.up Event flag to wait
until the connection is good before trying to flush.

Also truncates the buffer while the connection is down so that
it doesn't grow indefinitely.
